### PR TITLE
[Bugfix] Support Request url in fetch interceptor

### DIFF
--- a/src/interceptors/fetchInterceptor.js
+++ b/src/interceptors/fetchInterceptor.js
@@ -15,6 +15,8 @@ const fakeResponse = (response = {}, headers = {}) => {
 
 export const fakeService = config =>
   baseInterceptor(config, (helpers, url, options = {}) => {
+    url = url instanceof Request ? url.url : url;
+
     const body = options.body || '';
     const method = options.method || 'GET';
     const headers = options.headers || {};


### PR DESCRIPTION
This allow this kind of request now:

```javascript
const options = {
    method: 'POST'
 };
 const request = new Request('/todos');
 
 fetch(request, options).then(response => {
 
 });

```