### PR TITLE
Fixed bug, when xhrinterceptor lost body of the request

### DIFF
--- a/src/interceptors/xhrInterceptor.js
+++ b/src/interceptors/xhrInterceptor.js
@@ -93,7 +93,7 @@ const fakeService = helpers => class XMLHttpRequestInterceptor {
       onloadCallback && onloadCallback.call(xhr);
     };
 
-    return xhr.send();
+    return xhr.send(data);
   }
 
   setRequestHeader(name, value) {


### PR DESCRIPTION
When kakapo is used side-by-side with no-mocked server requests, xhrintereceptor misses body of the request (for PUT and POST), because it doesn't pass data argument to origing xhr.send