### PR TITLE
Passing status code, options to Response() constructor

### DIFF
--- a/src/interceptors/fetchInterceptor.js
+++ b/src/interceptors/fetchInterceptor.js
@@ -39,7 +39,7 @@ const fakeService = helpers => (url, options = {}) => {
     ));
   }
 
-  const result = fakeResponse(response.body, { headers: response.headers, status: response.code });
+  const result = fakeResponse(response.body, { headers: response.headers, status: response.code, ...response.options });
   return new Promise((resolve, reject) => setTimeout(
     () => {
       if (response.error) { return reject(result); }

--- a/src/interceptors/fetchInterceptor.js
+++ b/src/interceptors/fetchInterceptor.js
@@ -3,9 +3,9 @@ import { Request as KakapoRequest } from '../Request';
 import { interceptorHelper } from './interceptorHelper';
 
 let nativeFetch;
-const fakeResponse = (response = {}, headers = {}) => {
+const fakeResponse = (response = {}, options = {}) => {
   const responseStr = JSON.stringify(response);
-  return new window.Response(responseStr, { headers });
+  return new window.Response(responseStr, options);
 };
 const name = 'fetch';
 const fakeService = helpers => (url, options = {}) => {
@@ -39,7 +39,7 @@ const fakeService = helpers => (url, options = {}) => {
     ));
   }
 
-  const result = fakeResponse(response.body, response.headers);
+  const result = fakeResponse(response.body, { headers: response.headers, status: response.code });
   return new Promise((resolve, reject) => setTimeout(
     () => {
       if (response.error) { return reject(result); }

--- a/src/interceptors/fetchInterceptor.js
+++ b/src/interceptors/fetchInterceptor.js
@@ -39,7 +39,7 @@ const fakeService = helpers => (url, options = {}) => {
     ));
   }
 
-  const result = fakeResponse(response.body, { headers: response.headers, status: response.code, ...response.options });
+  const result = fakeResponse(response.body, Object.assign({}, response.options, { headers: response.headers, status: response.code } );
   return new Promise((resolve, reject) => setTimeout(
     () => {
       if (response.error) { return reject(result); }


### PR DESCRIPTION
Added a new field to KakapoResponse, ```options```, which is being passed on the ```window.Response(body, options)```. It can have ```statusText```, ```status``` (codes), and headers, and currently we are only passing headers. 

see #144 for a detailed explanation on why I suggest we do this, & another idea to being the ```fetchInterceptor``` behaviour closer to ```window.fetch```